### PR TITLE
Issue #1: Automated implementation

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,6 +16,16 @@ def get_plotly_template() -> str:
     return "plotly_dark" if base_theme == "dark" else "plotly_white"
 
 
+# Frequency mapping: single source of truth for dropdown and calculations
+FREQUENCY_OPTIONS = {
+    "Annually": 1,
+    "Half Yearly": 2,
+    "Quarterly": 4,
+    "Monthly": 12,
+    "Daily": 365,
+}
+
+
 def calculate_compound_balance(
     money_principal: float,
     money_monthly_contribution: float,
@@ -240,16 +250,10 @@ def render_sidebar_inputs() -> tuple[
         time_years = 0.0
         st.session_state["time_years_input"] = 0.0
 
-    frequency_options = {
-        "Annually": 1,
-        "Quarterly": 4,
-        "Monthly": 12,
-        "Daily": 365,
-    }
     frequency_label = st.sidebar.selectbox(
         "Compounding Frequency",
-        options=list(frequency_options.keys()),
-        index=2,
+        options=list(FREQUENCY_OPTIONS.keys()),
+        index=3,
     )
 
     return (
@@ -257,7 +261,7 @@ def render_sidebar_inputs() -> tuple[
         money_monthly_contribution,
         annual_rate_percent,
         time_years,
-        frequency_options[frequency_label],
+        FREQUENCY_OPTIONS[frequency_label],
         frequency_label,
         money_currency_code,
         money_currency_symbol,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -113,7 +113,7 @@ class TestCalculateCompoundBalance:
 class TestFrequencyImpact:
     """S2 – Frequency Impact"""
 
-    @pytest.mark.parametrize("n_low,n_high", [(1, 4), (4, 12), (12, 365)])
+    @pytest.mark.parametrize("n_low,n_high", [(1, 2), (2, 4), (4, 12), (12, 365)])
     def test_higher_frequency_yields_more_or_equal_balance(
         self, n_low: int, n_high: int
     ) -> None:
@@ -122,12 +122,16 @@ class TestFrequencyImpact:
         high = _balance(10000.0, 500.0, 6.0, 10.0, n_high)
         assert high >= low
 
+    def test_half_yearly_mapping_exists(self) -> None:
+        assert "Half Yearly" in app.FREQUENCY_OPTIONS
+        assert app.FREQUENCY_OPTIONS["Half Yearly"] == 2
+
     def test_frequency_has_no_impact_at_zero_rate(self) -> None:
         # All frequencies should produce identical results at 0% rate
-        results = [_balance(10000.0, 100.0, 0.0, 5.0, n) for n in (1, 4, 12, 365)]
+        results = [_balance(10000.0, 100.0, 0.0, 5.0, n) for n in (1, 2, 4, 12, 365)]
         assert all(isclose(r, results[0], rel_tol=1e-12) for r in results)
 
-    @pytest.mark.parametrize("n", [1, 4, 12, 365])
+    @pytest.mark.parametrize("n", [1, 2, 4, 12, 365])
     def test_all_frequencies_accept_fractional_years(self, n: int) -> None:
         result = _balance(1000.0, 50.0, 5.0, 2.5, n)
         assert isinstance(result, float) and result > 0
@@ -328,7 +332,7 @@ class TestEdgeCases:
         result = _balance(0.01, 0.01, 0.01, 0.1, 12)
         assert isinstance(result, float) and result > 0
 
-    @pytest.mark.parametrize("n", [1, 4, 12, 365])
+    @pytest.mark.parametrize("n", [1, 2, 4, 12, 365])
     def test_fractional_years_all_frequencies(self, n: int) -> None:
         # S6-5
         result = _balance(10000.0, 100.0, 5.0, 2.5, n)

--- a/ui-tests/regression/half-yearly.spec.ts
+++ b/ui-tests/regression/half-yearly.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+test('Half Yearly dropdown option and summary update', async ({ page }) => {
+  // Navigate to the running Streamlit app (default port)
+  await page.goto('http://localhost:8501', { waitUntil: 'networkidle' });
+
+  // Locate the sidebar label and the compounding frequency select. Streamlit renders
+  // a selectbox that can be addressed by its label. Use getByLabel for robustness.
+  const compSelect = page.getByLabel('Compounding Frequency');
+  await expect(compSelect).toBeVisible();
+
+  // Open the select and ensure Half Yearly appears as an option
+  await compSelect.click();
+  await expect(page.getByText('Half Yearly')).toBeVisible();
+
+  // Select Half Yearly and verify the summary caption updates accordingly
+  await page.getByText('Half Yearly').click();
+  await expect(page.getByText(/Projected using half yearly compounding/i)).toBeVisible();
+});


### PR DESCRIPTION
Closes #1

## Implementation
- Changed: app.py, tests/test_app.py, ui-tests/regression/half-yearly.spec.ts — implemented the requested issue behavior.

## Unit Tests
- Added/updated: Updated tests/test_app.py

## UI Regression Tests  
- Added/updated: Updated ui-tests/regression/ coverage

## Acceptance Criteria
- [x] Add Half Yearly as a selectable option in the compounding frequency dropdown.
- [x] Map Half Yearly to n = 2 in the compound interest calculation logic.
- [x] Use the half-yearly frequency consistently across the projected future value, total interest, growth chart, and year-over-year summary table.
- [x] Preserve existing behavior for Annually, Quarterly, and Monthly options.
- [x] Display the selected frequency label consistently in the UI and summary text.
- [x] Implement feature per problem statement
- [x] All unit tests passing
- [x] All UI tests passing
