### PR TITLE
Issue #4: Add Bi-Weekly (26) compounding frequency, replace Half Yearly

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,9 +19,9 @@ def get_plotly_template() -> str:
 # Frequency mapping: single source of truth for dropdown and calculations
 FREQUENCY_OPTIONS = {
     "Annually": 1,
-    "Half Yearly": 2,
     "Quarterly": 4,
     "Monthly": 12,
+    "Bi-Weekly": 26,
     "Weekly": 52,
     "Daily": 365,
 }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -113,7 +113,7 @@ class TestCalculateCompoundBalance:
 class TestFrequencyImpact:
     """S2 – Frequency Impact"""
 
-    @pytest.mark.parametrize("n_low,n_high", [(1, 2), (2, 4), (4, 12), (12, 52), (52, 365)])
+    @pytest.mark.parametrize("n_low,n_high", [(1, 4), (4, 12), (12, 26), (26, 52), (52, 365)])
     def test_higher_frequency_yields_more_or_equal_balance(
         self, n_low: int, n_high: int
     ) -> None:
@@ -122,9 +122,21 @@ class TestFrequencyImpact:
         high = _balance(10000.0, 500.0, 6.0, 10.0, n_high)
         assert high >= low
 
-    def test_half_yearly_mapping_exists(self) -> None:
-        assert "Half Yearly" in app.FREQUENCY_OPTIONS
-        assert app.FREQUENCY_OPTIONS["Half Yearly"] == 2
+    def test_bi_weekly_mapping_exists(self) -> None:
+        assert "Bi-Weekly" in app.FREQUENCY_OPTIONS
+        assert app.FREQUENCY_OPTIONS["Bi-Weekly"] == 26
+
+    def test_half_yearly_mapping_removed(self) -> None:
+        assert "Half Yearly" not in app.FREQUENCY_OPTIONS
+
+    def test_bi_weekly_frequency_compounds_correctly(self) -> None:
+        # S2-3: Bi-Weekly (n=26) should yield more than Monthly (n=12) and
+        # less than Weekly (n=52) at the same rate and principal
+        monthly = _balance(10000.0, 0.0, 6.0, 10.0, 12)
+        bi_weekly = _balance(10000.0, 0.0, 6.0, 10.0, 26)
+        weekly = _balance(10000.0, 0.0, 6.0, 10.0, 52)
+        assert bi_weekly > monthly
+        assert weekly >= bi_weekly
 
     def test_weekly_mapping_exists(self) -> None:
         assert "Weekly" in app.FREQUENCY_OPTIONS
@@ -132,10 +144,10 @@ class TestFrequencyImpact:
 
     def test_frequency_has_no_impact_at_zero_rate(self) -> None:
         # All frequencies should produce identical results at 0% rate
-        results = [_balance(10000.0, 100.0, 0.0, 5.0, n) for n in (1, 2, 4, 12, 52, 365)]
+        results = [_balance(10000.0, 100.0, 0.0, 5.0, n) for n in (1, 4, 12, 26, 52, 365)]
         assert all(isclose(r, results[0], rel_tol=1e-12) for r in results)
 
-    @pytest.mark.parametrize("n", [1, 2, 4, 12, 52, 365])
+    @pytest.mark.parametrize("n", [1, 4, 12, 26, 52, 365])
     def test_all_frequencies_accept_fractional_years(self, n: int) -> None:
         result = _balance(1000.0, 50.0, 5.0, 2.5, n)
         assert isinstance(result, float) and result > 0
@@ -336,7 +348,7 @@ class TestEdgeCases:
         result = _balance(0.01, 0.01, 0.01, 0.1, 12)
         assert isinstance(result, float) and result > 0
 
-    @pytest.mark.parametrize("n", [1, 2, 4, 12, 52, 365])
+    @pytest.mark.parametrize("n", [1, 4, 12, 26, 52, 365])
     def test_fractional_years_all_frequencies(self, n: int) -> None:
         # S6-5
         result = _balance(10000.0, 100.0, 5.0, 2.5, n)

--- a/ui-tests/regression/half-yearly.spec.ts
+++ b/ui-tests/regression/half-yearly.spec.ts
@@ -1,19 +1,20 @@
 import { test, expect } from '@playwright/test';
 
-test('Half Yearly dropdown option and summary update', async ({ page }) => {
-  // Navigate to the running Streamlit app (default port)
-  await page.goto('http://localhost:8501', { waitUntil: 'networkidle' });
+test('Bi-Weekly dropdown option and summary update', async ({ page }) => {
+  // Navigate to the running Streamlit app using the configured base URL
+  await page.goto('/');
 
   // Locate the sidebar label and the compounding frequency select. Streamlit renders
   // a selectbox that can be addressed by its label. Use getByLabel for robustness.
   const compSelect = page.getByLabel('Compounding Frequency');
   await expect(compSelect).toBeVisible();
 
-  // Open the select and ensure Half Yearly appears as an option
+  // Open the select and ensure Bi-Weekly appears as an option
   await compSelect.click();
-  await expect(page.getByText('Half Yearly')).toBeVisible();
+  const dropdown = page.getByTestId('stSelectboxVirtualDropdown');
+  await expect(dropdown.getByText('Bi-Weekly')).toBeVisible();
 
-  // Select Half Yearly and verify the summary caption updates accordingly
-  await page.getByText('Half Yearly').click();
-  await expect(page.getByText(/Projected using half yearly compounding/i)).toBeVisible();
+  // Select Bi-Weekly and verify the summary caption updates accordingly
+  await dropdown.getByText('Bi-Weekly').click();
+  await expect(page.getByText(/Projected using bi-weekly compounding/i)).toBeVisible();
 });

--- a/ui-tests/regression/positive/calculator.frequency.spec.ts
+++ b/ui-tests/regression/positive/calculator.frequency.spec.ts
@@ -5,18 +5,39 @@ async function selectCompoundingFrequency(
   frequency: string
 ) {
   await page.getByLabel("Compounding Frequency").click();
-  await page.getByText(frequency, { exact: true }).click();
+  const dropdown = page.getByTestId('stSelectboxVirtualDropdown');
+  await dropdown.getByText(frequency, { exact: true }).click();
 }
 
 test.describe("UI Regression Positive - Frequency", () => {
   test("all compounding frequencies are selectable", async ({ page }) => {
     await page.goto("/");
 
-    for (const frequency of ["Annually", "Quarterly", "Monthly", "Weekly", "Daily"]) {
+    for (const frequency of ["Annually", "Quarterly", "Monthly", "Bi-Weekly", "Weekly", "Daily"]) {
       await selectCompoundingFrequency(page, frequency);
       await expect(
         page.getByText(new RegExp(`Projected using ${frequency.toLowerCase()} compounding`))
       ).toBeVisible();
     }
+  });
+
+  test("Bi-Weekly option is present and selectable in dropdown", async ({ page }) => {
+    await page.goto("/");
+
+    await page.getByLabel("Compounding Frequency").click();
+    const dropdown = page.getByTestId('stSelectboxVirtualDropdown');
+    await expect(dropdown.getByText("Bi-Weekly", { exact: true })).toBeVisible();
+    await dropdown.getByText("Bi-Weekly", { exact: true }).click();
+    await expect(
+      page.getByText(/Projected using bi-weekly compounding/i)
+    ).toBeVisible();
+  });
+
+  test("Half Yearly option is no longer present in dropdown", async ({ page }) => {
+    await page.goto("/");
+
+    await page.getByLabel("Compounding Frequency").click();
+    const dropdown = page.getByTestId('stSelectboxVirtualDropdown');
+    await expect(dropdown.getByText("Half Yearly", { exact: true })).not.toBeVisible();
   });
 });

--- a/ui-tests/regression/weekly.spec.ts
+++ b/ui-tests/regression/weekly.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from '@playwright/test';
 
 test('Weekly dropdown option and summary update', async ({ page }) => {
-  // Navigate to the running Streamlit app (default port)
-  await page.goto('http://localhost:8501', { waitUntil: 'networkidle' });
+  // Navigate to the running Streamlit app using the configured base URL
+  await page.goto('/');
 
   // Locate the sidebar label and the compounding frequency select. Streamlit renders
   // a selectbox that can be addressed by its label. Use getByLabel for robustness.
@@ -11,9 +11,10 @@ test('Weekly dropdown option and summary update', async ({ page }) => {
 
   // Open the select and ensure Weekly appears as an option
   await compSelect.click();
-  await expect(page.getByText('Weekly')).toBeVisible();
+  const dropdown = page.getByTestId('stSelectboxVirtualDropdown');
+  await expect(dropdown.getByText('Weekly', { exact: true })).toBeVisible();
 
   // Select Weekly and verify the summary caption updates accordingly
-  await page.getByText('Weekly').click();
+  await dropdown.getByText('Weekly', { exact: true }).click();
   await expect(page.getByText(/Projected using weekly compounding/i)).toBeVisible();
 });


### PR DESCRIPTION
## Summary

Closes #4

Replaces the non-canonical `"Half Yearly": 2` compounding frequency with `"Bi-Weekly": 26` to align with the project's single source of truth:
`Annually=1, Quarterly=4, Monthly=12, **Bi-Weekly=26**, Weekly=52, Daily=365`

---

## Traceability Checklist

### ✅ Gate 1 — app.py change
| File | Line(s) | Change |
|------|---------|--------|
| `app.py` | 20-27 | Replaced `"Half Yearly": 2` with `"Bi-Weekly": 26` in `FREQUENCY_OPTIONS` dict (canonical source of truth) |

### ✅ Gate 2 — Unit Tests (tests/test_app.py)
| Test | Action | Covers |
|------|--------|--------|
| `TestFrequencyImpact::test_bi_weekly_mapping_exists` | **Added** | Asserts `FREQUENCY_OPTIONS["Bi-Weekly"] == 26` |
| `TestFrequencyImpact::test_half_yearly_mapping_removed` | **Added** | Asserts `"Half Yearly" not in FREQUENCY_OPTIONS` |
| `TestFrequencyImpact::test_bi_weekly_frequency_compounds_correctly` | **Added** | Asserts Bi-Weekly (n=26) yields more than Monthly (n=12) and ≤ Weekly (n=52) |
| `TestFrequencyImpact::test_higher_frequency_yields_more_or_equal_balance` | **Updated** | Parametrize updated: `(1,4),(4,12),(12,26),(26,52),(52,365)` — removes n=2, adds n=26 |
| `TestFrequencyImpact::test_frequency_has_no_impact_at_zero_rate` | **Updated** | Frequency list updated to `(1, 4, 12, 26, 52, 365)` |
| `TestFrequencyImpact::test_all_frequencies_accept_fractional_years` | **Updated** | Parametrize updated to `[1, 4, 12, 26, 52, 365]` |
| `TestEdgeCases::test_fractional_years_all_frequencies` | **Updated** | Parametrize updated to `[1, 4, 12, 26, 52, 365]` |

**Result: 80/80 tests pass ✅**

### ✅ Gate 3 — Playwright UI Tests (ui-tests/regression/)
| File | Test | Action | Covers |
|------|------|--------|--------|
| `half-yearly.spec.ts` | `Bi-Weekly dropdown option and summary update` | **Updated** | Verifies Bi-Weekly appears in dropdown and caption updates |
| `weekly.spec.ts` | `Weekly dropdown option and summary update` | **Updated** | Fixed port (use `/` baseURL) and exact-match selector to avoid Bi-Weekly collision |
| `positive/calculator.frequency.spec.ts` | `all compounding frequencies are selectable` | **Updated** | Added Bi-Weekly to the iterated frequency list |
| `positive/calculator.frequency.spec.ts` | `Bi-Weekly option is present and selectable in dropdown` | **Added** | Dedicated test: opens dropdown, verifies Bi-Weekly visible, selects it, verifies caption |
| `positive/calculator.frequency.spec.ts` | `Half Yearly option is no longer present in dropdown` | **Added** | Asserts Half Yearly is absent from the dropdown |

**Result: 16/16 Playwright tests pass ✅**

### ✅ Gate 4 — Acceptance Criteria Coverage
- [x] Bi-Weekly (26) frequency added to `FREQUENCY_OPTIONS`
- [x] Half Yearly (2) removed (was not in canonical reference)
- [x] Canonical reference fully satisfied: Annually=1, Quarterly=4, Monthly=12, Bi-Weekly=26, Weekly=52, Daily=365
- [x] All unit tests passing (80/80)
- [x] All UI tests passing (16/16)
- [x] No breaking changes to existing UI — existing frequencies unchanged