### PR TITLE
Issue #16: Add Semi-Monthly compounding frequency option

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,6 +22,7 @@ FREQUENCY_OPTIONS = {
     "Half Yearly": 2,
     "Quarterly": 4,
     "Monthly": 12,
+    "Semi-Monthly": 24,
     "Weekly": 52,
     "Daily": 365,
 }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -113,7 +113,7 @@ class TestCalculateCompoundBalance:
 class TestFrequencyImpact:
     """S2 – Frequency Impact"""
 
-    @pytest.mark.parametrize("n_low,n_high", [(1, 2), (2, 4), (4, 12), (12, 52), (52, 365)])
+    @pytest.mark.parametrize("n_low,n_high", [(1, 2), (2, 4), (4, 12), (12, 24), (24, 52), (52, 365)])
     def test_higher_frequency_yields_more_or_equal_balance(
         self, n_low: int, n_high: int
     ) -> None:
@@ -130,12 +130,38 @@ class TestFrequencyImpact:
         assert "Weekly" in app.FREQUENCY_OPTIONS
         assert app.FREQUENCY_OPTIONS["Weekly"] == 52
 
+    def test_semi_monthly_mapping_exists(self) -> None:
+        # Issue #16: Semi-Monthly must be present and mapped to 24
+        assert "Semi-Monthly" in app.FREQUENCY_OPTIONS
+        assert app.FREQUENCY_OPTIONS["Semi-Monthly"] == 24
+
+    def test_semi_monthly_frequency_compounds_correctly(self) -> None:
+        # Issue #16: Semi-Monthly (n=24) should produce a higher balance than
+        # Monthly (n=12) and a lower balance than Weekly (n=52) at a positive rate.
+        monthly = _balance(10000.0, 0.0, 6.0, 10.0, 12)
+        semi_monthly = _balance(10000.0, 0.0, 6.0, 10.0, 24)
+        weekly = _balance(10000.0, 0.0, 6.0, 10.0, 52)
+        assert semi_monthly > monthly, "Semi-Monthly should compound more than Monthly"
+        assert semi_monthly < weekly, "Semi-Monthly should compound less than Weekly"
+
+    def test_semi_monthly_balance_formula(self) -> None:
+        # Issue #16: Verify the exact compound formula for n=24 over 1 year at 12%
+        # FV = P * (1 + 0.12/24)^24
+        import math
+        principal = 1000.0
+        rate = 12.0
+        years = 1.0
+        n = 24
+        expected = principal * (1 + (rate / 100) / n) ** (n * years)
+        result = _balance(principal, 0.0, rate, years, n)
+        assert isclose(result, expected, rel_tol=1e-12)
+
     def test_frequency_has_no_impact_at_zero_rate(self) -> None:
         # All frequencies should produce identical results at 0% rate
-        results = [_balance(10000.0, 100.0, 0.0, 5.0, n) for n in (1, 2, 4, 12, 52, 365)]
+        results = [_balance(10000.0, 100.0, 0.0, 5.0, n) for n in (1, 2, 4, 12, 24, 52, 365)]
         assert all(isclose(r, results[0], rel_tol=1e-12) for r in results)
 
-    @pytest.mark.parametrize("n", [1, 2, 4, 12, 52, 365])
+    @pytest.mark.parametrize("n", [1, 2, 4, 12, 24, 52, 365])
     def test_all_frequencies_accept_fractional_years(self, n: int) -> None:
         result = _balance(1000.0, 50.0, 5.0, 2.5, n)
         assert isinstance(result, float) and result > 0
@@ -336,7 +362,7 @@ class TestEdgeCases:
         result = _balance(0.01, 0.01, 0.01, 0.1, 12)
         assert isinstance(result, float) and result > 0
 
-    @pytest.mark.parametrize("n", [1, 2, 4, 12, 52, 365])
+    @pytest.mark.parametrize("n", [1, 2, 4, 12, 24, 52, 365])
     def test_fractional_years_all_frequencies(self, n: int) -> None:
         # S6-5
         result = _balance(10000.0, 100.0, 5.0, 2.5, n)

--- a/ui-tests/regression/positive/calculator.frequency.spec.ts
+++ b/ui-tests/regression/positive/calculator.frequency.spec.ts
@@ -12,7 +12,7 @@ test.describe("UI Regression Positive - Frequency", () => {
   test("all compounding frequencies are selectable", async ({ page }) => {
     await page.goto("/");
 
-    for (const frequency of ["Annually", "Quarterly", "Monthly", "Weekly", "Daily"]) {
+    for (const frequency of ["Annually", "Quarterly", "Monthly", "Semi-Monthly", "Weekly", "Daily"]) {
       await selectCompoundingFrequency(page, frequency);
       await expect(
         page.getByText(new RegExp(`Projected using ${frequency.toLowerCase()} compounding`))

--- a/ui-tests/regression/semi-monthly.spec.ts
+++ b/ui-tests/regression/semi-monthly.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+
+test('Semi-Monthly dropdown option is visible and selectable', async ({ page }) => {
+  // Navigate to the running Streamlit app using the configured baseURL
+  await page.goto('/');
+
+  // Open the Compounding Frequency selectbox and verify "Semi-Monthly" appears
+  await page.getByLabel('Compounding Frequency').click();
+  await expect(page.getByText('Semi-Monthly', { exact: true })).toBeVisible();
+
+  // Select Semi-Monthly and verify the summary caption reflects it
+  await page.getByText('Semi-Monthly', { exact: true }).click();
+  await expect(page.getByText(/Projected using semi-monthly compounding/i)).toBeVisible();
+});


### PR DESCRIPTION
## Summary
Closes #16

Adds "Semi-Monthly" (24 compounds/year) as a new option in the Compounding Frequency dropdown.

## Traceability Checklist

### app.py changes
- **Line 25** — Added `"Semi-Monthly": 24` to `FREQUENCY_OPTIONS` dict (between Monthly=12 and Weekly=52). This is the single source of truth for the Compounding Frequency dropdown and drives both the UI selectbox and the compound interest calculation.

### Unit tests added/updated — tests/test_app.py
- `TestFrequencyImpact::test_semi_monthly_mapping_exists` — asserts `FREQUENCY_OPTIONS["Semi-Monthly"] == 24`
- `TestFrequencyImpact::test_semi_monthly_frequency_compounds_correctly` — asserts Semi-Monthly balance > Monthly and < Weekly (monotonically ordered)
- `TestFrequencyImpact::test_semi_monthly_balance_formula` — verifies exact compound formula `P*(1+r/24)^24` for n=24
- `TestFrequencyImpact::test_higher_frequency_yields_more_or_equal_balance` — extended parametrize to include `(12,24)` and `(24,52)` pairs
- `TestFrequencyImpact::test_frequency_has_no_impact_at_zero_rate` — extended to include n=24
- `TestFrequencyImpact::test_all_frequencies_accept_fractional_years` — extended parametrize to include n=24
- `TestEdgeCases::test_fractional_years_all_frequencies` — extended parametrize to include n=24

### Playwright UI tests added/updated — ui-tests/regression/
- `ui-tests/regression/semi-monthly.spec.ts` — new spec: opens the Compounding Frequency dropdown, asserts "Semi-Monthly" is visible and selectable, and verifies the caption updates to "semi-monthly compounding"
- `ui-tests/regression/positive/calculator.frequency.spec.ts` — added "Semi-Monthly" to the comprehensive all-frequencies loop test

## Acceptance Criteria Verification
- [x] "Semi-Monthly" appears as a selectable option in the Compounding Frequency dropdown — verified by `semi-monthly.spec.ts` (UI) and `test_semi_monthly_mapping_exists` (unit)
- [x] Selecting "Semi-Monthly" compounds interest 24 times per year — verified by `test_semi_monthly_balance_formula` and `test_semi_monthly_frequency_compounds_correctly`

## Test Results
- Unit tests: **83 passed**, 1 pre-existing failure in `test_workflow_personas.py` (unrelated to this change)
- UI regression: **13 passed** (including both new Semi-Monthly tests), 2 pre-existing failures in `half-yearly.spec.ts` and `weekly.spec.ts` (use hardcoded port 8501, not introduced by this PR)