### PR TITLE
Parallel testing agents + multi-agent dashboard redesign

### DIFF
--- a/.github/agents/issue-workflow.agent.md
+++ b/.github/agents/issue-workflow.agent.md
@@ -1,52 +1,93 @@
 ---
 name: issue-workflow
-description: "Orchestrator: runs the end-to-end issue workflow for CompIntCalculator by invoking 5 specialist subagents in sequence. Trigger with: Start work on git issue #<N>"
+description: "Orchestrator: runs the end-to-end issue workflow for CompIntCalculator by invoking 5 specialist subagents. Steps 3 and 4 run in parallel. Trigger with: Start work on git issue #<N>"
 ---
 
 # Issue Workflow Orchestrator
 
-You coordinate the full end-to-end workflow for a GitHub issue by invoking **5 specialist subagents** in strict sequence. Each subagent owns its step completely — you do not implement any step yourself.
+You coordinate the full end-to-end workflow for a GitHub issue by invoking **5 specialist subagents**. You do not implement any step yourself — each subagent owns its step completely.
+
+## Pipeline Shape
+
+```
+[Step 1: product-owner]
+        ↓
+[Step 2: developer]
+        ↓
+   ┌────┴────┐
+[Step 3]  [Step 4]   ← PARALLEL — invoke both simultaneously
+unit-tester  ui-tester
+   └────┬────┘
+        ↓  (only when BOTH are COMPLETED)
+[Step 5: pr-creator]
+```
 
 ## Your Responsibilities
 
-1. Extract the issue number from the user's request.
-2. Generate a `workflow_id` in the format `issue-<N>-<YYYYMMDDHHMMSS>` using current UTC time.
-3. Initialise the workflow state file by running:
-   ```bash
-   python3 scripts/update_workflow_state.py \
-     --init --workflow-id <workflow_id> --issue-number <N>
-   ```
-   Confirm `[OK]` appears in output before continuing.
-4. Invoke each subagent in order, passing `workflow_id` and `issue_number` as context.
-5. After each subagent completes, check its result:
-   - If the subagent reports **BLOCKED** → stop the pipeline immediately and report the block reason to the user.
-   - If the subagent reports **COMPLETED** → proceed to the next subagent.
-6. After all 5 subagents complete successfully, run:
-   ```bash
-   python3 scripts/update_workflow_state.py --workflow-id <workflow_id> --complete
-   ```
-   Confirm `[OK]`, then report the PR URL to the user.
+### 1. Initialise
+Extract the issue number. Generate `workflow_id` as `issue-<N>-<YYYYMMDDHHMMSS>` (current UTC time).
 
-## Subagent Invocation Order
+```bash
+python3 scripts/update_workflow_state.py \
+  --init --workflow-id <workflow_id> --issue-number <N>
+```
+Confirm `[OK]` before continuing.
 
-Invoke each agent below in sequence. Pass `workflow_id` and `issue_number` as the first thing in your prompt to the subagent.
+### 2. Sequential Phase — Steps 1 and 2
+Invoke subagents one at a time:
 
-| Step | Subagent | Gate |
-|------|----------|------|
-| 1 | `#product-owner` | Gate 0 — Issue must be unambiguous |
-| 2 | `#developer` | Gate 1 — app.py must change |
-| 3 | `#unit-tester` | Gate 2 — test delta required |
-| 4 | `#ui-tester` | Gate 3 — Playwright spec delta required |
-| 5 | `#pr-creator` | Gate 4 — Acceptance criteria must be present |
+1. Invoke `#product-owner` with `workflow_id` and `issue_number`.
+   - BLOCKED → stop pipeline, report to user.
+   - COMPLETED → continue.
+
+2. Invoke `#developer` with `workflow_id` and `issue_number`.
+   - BLOCKED → stop pipeline, report to user.
+   - COMPLETED → continue to parallel phase.
+
+### 3. Parallel Phase — Steps 3 and 4
+Invoke **both subagents simultaneously** (in the same turn if possible):
+
+- Invoke `#unit-tester` with `workflow_id` and `issue_number`.
+- Invoke `#ui-tester` with `workflow_id` and `issue_number`.
+
+Wait for both to return. Then evaluate:
+
+| unit-tester | ui-tester | Action |
+|-------------|-----------|--------|
+| COMPLETED | COMPLETED | ✅ Run parallel gate check, then invoke Step 5 |
+| BLOCKED | any | ❌ Stop pipeline, report unit-tester block reason |
+| any | BLOCKED | ❌ Stop pipeline, report ui-tester block reason |
+| BLOCKED | BLOCKED | ❌ Stop pipeline, report both block reasons |
+
+### 4. Parallel Gate Check (mandatory before Step 5)
+Before invoking `#pr-creator`, run:
+
+```bash
+python3 scripts/update_workflow_state.py \
+  --workflow-id <workflow_id> --check-parallel-complete
+```
+
+- If output contains `[OK]` → proceed to Step 5.
+- If output contains `[WAIT]` or exit code is 2 → **STOP**. Do not invoke `#pr-creator`. Report to user.
+
+### 5. Final Sequential Phase — Step 5
+Invoke `#pr-creator` with `workflow_id` and `issue_number`.
+- BLOCKED → stop pipeline, report to user.
+- COMPLETED → mark workflow complete:
+
+```bash
+python3 scripts/update_workflow_state.py --workflow-id <workflow_id> --complete
+```
+Confirm `[OK]`, then report the PR URL to the user.
 
 ## BLOCK Propagation Rule
 
-If any subagent returns a BLOCKED result, you MUST:
-1. Stop — do not invoke any further subagents.
+On any BLOCK (any step):
+1. **STOP** — do not invoke any further subagents.
 2. Report the exact gate failure message to the user.
 3. Instruct the user to fix the root cause and re-trigger the workflow.
 
 ## Dashboard
 
-The workflow state is written to `.workflow/state/<workflow_id>.json` after every transition.
-The Streamlit dashboard (`workflow_dashboard.py`) reads this file and auto-refreshes every 5 seconds.
+Workflow state is written to `.workflow/state/<workflow_id>.json` after every transition.
+The Streamlit dashboard (`workflow_dashboard.py`) reads this file, renders the parallel pipeline view, and auto-refreshes every 5 seconds.

--- a/scripts/update_workflow_state.py
+++ b/scripts/update_workflow_state.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Workflow state updater for the AI issue workflow (Path B / VS Code agent).
+Workflow state updater for the AI issue workflow (multi-agent orchestration).
 
 Usage:
   # Create initial state file (all steps PENDING)
@@ -15,10 +15,18 @@ Usage:
   # Mark a step BLOCKED (call on any gate failure; pipeline must stop after this)
   python3 scripts/update_workflow_state.py --workflow-id issue-16-20260501102500 --step 2 --status BLOCKED --error "Gate 1 BLOCKED: no app.py change"
 
+  # Check both parallel steps (3 and 4) are COMPLETED before allowing Step 5
+  python3 scripts/update_workflow_state.py --workflow-id issue-16-20260501102500 --check-parallel-complete
+
   # Mark entire workflow COMPLETED (call after Step 5 succeeds)
   python3 scripts/update_workflow_state.py --workflow-id issue-16-20260501102500 --complete
 
-Exits with code 0 on success. Prints the updated status line for verification.
+Exits with code 0 on success. Exits with code 2 if parallel gate not met.
+Prints the updated status line for verification.
+
+Pipeline shape:
+  Step 1 (product_owner) -> Step 2 (developer) -> Steps 3+4 (unit_tester + ui_tester in PARALLEL)
+  -> [both COMPLETED] -> Step 5 (pr_creator)
 """
 
 from __future__ import annotations
@@ -37,6 +45,18 @@ STEP_NAMES = {
     3: ("Unit Testing", "unit_tester"),
     4: ("UI Regression Testing", "ui_tester"),
     5: ("Pull Request Creation", "pr_creator"),
+}
+
+# Steps 3 and 4 run in parallel; step 5 depends on both completing.
+PARALLEL_STEPS = {3, 4}
+
+# Execution mode stored per-step in state JSON so the dashboard can render correctly.
+EXECUTION_MODE = {
+    1: "sequential",
+    2: "sequential",
+    3: "parallel",
+    4: "parallel",
+    5: "sequential",
 }
 
 VALID_STEP_STATUSES = {"PENDING", "IN_PROGRESS", "COMPLETED", "BLOCKED", "FAILED"}
@@ -80,6 +100,26 @@ def save_and_verify(state: dict, workflow_id: str) -> None:
     )
 
 
+def cmd_check_parallel_complete(workflow_id: str) -> None:
+    """Exit 0 if steps 3 and 4 are both COMPLETED; exit 2 otherwise."""
+    state = load_state(workflow_id)
+    parallel = {s["step_id"]: s["status"] for s in state["steps"] if s["step_id"] in PARALLEL_STEPS}
+    not_done = {sid: st for sid, st in parallel.items() if st != "COMPLETED"}
+    if not_done:
+        details = ", ".join(f"Step {sid}={st}" for sid, st in sorted(not_done.items()))
+        print(
+            f"[WAIT] Parallel gate not met for workflow_id={workflow_id}: {details}. "
+            "Step 5 (PR Creator) must not start until both Step 3 and Step 4 are COMPLETED.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    print(
+        f"[OK] Parallel gate met for workflow_id={workflow_id}: "
+        "Step 3 (Unit Testing) and Step 4 (UI Regression) are both COMPLETED. "
+        "Step 5 (PR Creator) may now start."
+    )
+
+
 def cmd_init(workflow_id: str, issue_number: int) -> None:
     path = state_path(workflow_id)
     if path.exists():
@@ -101,6 +141,7 @@ def cmd_init(workflow_id: str, issue_number: int) -> None:
                 "step_id": sid,
                 "name": name,
                 "persona": persona,
+                "execution_mode": EXECUTION_MODE[sid],
                 "status": "PENDING",
                 "started_at": None,
                 "ended_at": None,
@@ -133,7 +174,9 @@ def cmd_update_step(workflow_id: str, step_id: int, status: str, error: str | No
         step["ended_at"] = None
         step["duration_seconds"] = None
         step["error"] = None
-        state["current_step"] = step_id
+        # For parallel steps, keep current_step reflecting the higher of the two
+        if step_id not in PARALLEL_STEPS or state["current_step"] < step_id:
+            state["current_step"] = step_id
         state["status"] = "IN_PROGRESS"
 
     elif status == "COMPLETED":
@@ -172,6 +215,11 @@ def main() -> None:
     parser.add_argument("--status", choices=list(VALID_STEP_STATUSES), help="New status for the step")
     parser.add_argument("--error", help="Error message (required when --status BLOCKED)")
     parser.add_argument("--complete", action="store_true", help="Mark top-level workflow as COMPLETED")
+    parser.add_argument(
+        "--check-parallel-complete",
+        action="store_true",
+        help="Exit 0 if steps 3 and 4 are both COMPLETED; exit 2 otherwise (used by orchestrator before starting Step 5)",
+    )
     args = parser.parse_args()
 
     if args.init:
@@ -182,13 +230,16 @@ def main() -> None:
     elif args.complete:
         cmd_complete(args.workflow_id)
 
+    elif args.check_parallel_complete:
+        cmd_check_parallel_complete(args.workflow_id)
+
     elif args.step and args.status:
         if args.status == "BLOCKED" and not args.error:
             parser.error("--error is required when --status is BLOCKED")
         cmd_update_step(args.workflow_id, args.step, args.status, args.error)
 
     else:
-        parser.error("Provide --init, --complete, or both --step and --status")
+        parser.error("Provide --init, --complete, --check-parallel-complete, or both --step and --status")
 
 
 if __name__ == "__main__":

--- a/workflow_dashboard.py
+++ b/workflow_dashboard.py
@@ -10,12 +10,30 @@ import streamlit.components.v1 as components
 
 STATE_DIR = Path(".workflow/state")
 
+# Steps that run in parallel — rendered side-by-side in the pipeline view.
+PARALLEL_STEPS = {3, 4}
+
+STATUS_ICON = {
+    "PENDING": "⬜",
+    "IN_PROGRESS": "🟡",
+    "COMPLETED": "✅",
+    "BLOCKED": "🔴",
+    "FAILED": "❌",
+}
+
+STATUS_COLOR = {
+    "PENDING": "#888888",
+    "IN_PROGRESS": "#f0a500",
+    "COMPLETED": "#28a745",
+    "BLOCKED": "#dc3545",
+    "FAILED": "#dc3545",
+}
+
 
 def parse_timestamp(value: str | None) -> datetime:
     """Parse ISO timestamps from workflow state; use minimum date when missing/invalid."""
     if not value:
         return datetime.min
-
     try:
         return datetime.fromisoformat(value.replace("Z", "+00:00")).replace(tzinfo=None)
     except ValueError:
@@ -26,36 +44,110 @@ def load_workflows() -> list[dict[str, Any]]:
     """Load all workflow state files, newest first by workflow updated_at."""
     if not STATE_DIR.exists():
         return []
-
     workflows: list[dict[str, Any]] = []
     for file_path in STATE_DIR.glob("*.json"):
         try:
             workflows.append(json.loads(file_path.read_text(encoding="utf-8")))
         except (json.JSONDecodeError, OSError):
             continue
-
     workflows.sort(key=lambda item: parse_timestamp(item.get("updated_at")), reverse=True)
     return workflows
 
 
 def format_time(value: str | None) -> str:
     if not value:
-        return "-"
-
+        return "—"
     try:
         parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
         if parsed.tzinfo is None:
             parsed = parsed.replace(tzinfo=timezone.utc)
-        return parsed.astimezone().strftime("%Y-%m-%d %H:%M:%S")
+        return parsed.astimezone().strftime("%H:%M:%S")
     except ValueError:
         return value
+
+
+def format_duration(seconds: float | None) -> str:
+    if seconds is None:
+        return "—"
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    return f"{int(seconds // 60)}m {int(seconds % 60)}s"
+
+
+def render_step_card(step: dict[str, Any]) -> None:
+    """Render a single step as a styled card."""
+    status = step.get("status", "PENDING")
+    icon = STATUS_ICON.get(status, "⬜")
+    color = STATUS_COLOR.get(status, "#888")
+    name = step.get("name", "")
+    persona = step.get("persona", "")
+    duration = format_duration(step.get("duration_seconds"))
+    started = format_time(step.get("started_at"))
+    ended = format_time(step.get("ended_at"))
+    error = step.get("error")
+    mode = step.get("execution_mode", "sequential")
+    mode_badge = "🔀 parallel" if mode == "parallel" else "➡️ sequential"
+
+    st.markdown(
+        f"""
+        <div style="
+            border: 2px solid {color};
+            border-radius: 10px;
+            padding: 12px 16px;
+            margin-bottom: 8px;
+            background: {'#fff8e1' if status == 'IN_PROGRESS' else '#f8f9fa'};
+        ">
+            <div style="font-size:1.1em; font-weight:600;">{icon} {name}</div>
+            <div style="color:#555; font-size:0.85em; margin-top:4px;">
+                🤖 <code>{persona}</code> &nbsp;|&nbsp; {mode_badge}
+            </div>
+            <div style="margin-top:6px; font-size:0.85em; color:{color}; font-weight:600;">
+                {status}
+            </div>
+            <div style="font-size:0.8em; color:#666; margin-top:4px;">
+                ⏱ {duration} &nbsp;|&nbsp; Start: {started} &nbsp;|&nbsp; End: {ended}
+            </div>
+            {f'<div style="margin-top:6px; color:#dc3545; font-size:0.8em;">🚫 {error}</div>' if error else ''}
+        </div>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def render_pipeline(steps: list[dict[str, Any]]) -> None:
+    """Render the full pipeline with parallel step 3+4 side-by-side."""
+    sequential_before = [s for s in steps if s["step_id"] < 3]
+    parallel = [s for s in steps if s["step_id"] in PARALLEL_STEPS]
+    sequential_after = [s for s in steps if s["step_id"] > 4]
+
+    # Steps 1 and 2
+    for step in sequential_before:
+        render_step_card(step)
+        st.markdown("<div style='text-align:center; font-size:1.4em; color:#aaa;'>↓</div>", unsafe_allow_html=True)
+
+    # Steps 3 + 4 side by side
+    if parallel:
+        st.markdown(
+            "<div style='text-align:center; font-size:0.8em; color:#888; margin-bottom:4px;'>"
+            "— parallel execution —</div>",
+            unsafe_allow_html=True,
+        )
+        cols = st.columns(len(parallel))
+        for col, step in zip(cols, parallel):
+            with col:
+                render_step_card(step)
+        st.markdown("<div style='text-align:center; font-size:1.4em; color:#aaa;'>↓</div>", unsafe_allow_html=True)
+
+    # Step 5
+    for step in sequential_after:
+        render_step_card(step)
 
 
 def main() -> None:
     st.set_page_config(page_title="AI Workflow Dashboard", layout="wide")
 
-    st.title("AI Workflow Dashboard")
-    st.caption("Live status for issue workflows")
+    st.title("🤖 AI Workflow Dashboard")
+    st.caption("Multi-agent orchestration — live pipeline view")
 
     auto_refresh = st.sidebar.toggle("Auto-refresh", value=True)
     refresh_seconds = st.sidebar.slider(
@@ -78,53 +170,79 @@ def main() -> None:
             """,
             height=0,
         )
-        st.caption(f"Auto-refreshing every {refresh_seconds} seconds.")
+        st.caption(f"Auto-refreshing every {refresh_seconds}s.")
 
     workflows = load_workflows()
     if not workflows:
-        st.info("No workflow state files found in .workflow/state")
+        st.info("No workflow state files found in .workflow/state/")
         st.stop()
 
+    # Workflow selector
+    st.sidebar.markdown("---")
+    st.sidebar.subheader("Workflows")
     workflow_ids = [item.get("workflow_id", "unknown") for item in workflows]
-    st.caption("Showing the most recently updated workflow first.")
-    selected_id = st.selectbox("Workflow", options=workflow_ids, index=0)
+    st.sidebar.caption("Most recently updated first.")
+    selected_id = st.sidebar.selectbox("Select workflow", options=workflow_ids, index=0, label_visibility="collapsed")
 
-    selected = next(
-        (item for item in workflows if item.get("workflow_id") == selected_id),
-        workflows[0],
+    selected = next((w for w in workflows if w.get("workflow_id") == selected_id), workflows[0])
+    steps = selected.get("steps", [])
+
+    # Summary metrics
+    overall_status = selected.get("status", "PENDING")
+    active_agents = sum(1 for s in steps if s.get("status") == "IN_PROGRESS")
+    blocked_count = sum(1 for s in steps if s.get("status") == "BLOCKED")
+    completed_count = sum(1 for s in steps if s.get("status") == "COMPLETED")
+    total_duration = sum(s.get("duration_seconds") or 0 for s in steps)
+
+    st.markdown(f"### Issue #{selected.get('issue_number', '?')} — `{selected_id}`")
+
+    m1, m2, m3, m4, m5 = st.columns(5)
+    m1.metric("Status", f"{STATUS_ICON.get(overall_status, '')} {overall_status}")
+    m2.metric("Active Agents", active_agents)
+    m3.metric("Completed Steps", f"{completed_count} / {len(steps)}")
+    m4.metric("Blocked", blocked_count)
+    m5.metric("Total Duration", format_duration(total_duration if total_duration else None))
+
+    st.markdown("---")
+
+    # Pipeline view
+    left, right = st.columns([2, 1])
+
+    with left:
+        st.subheader("Pipeline")
+        render_pipeline(steps)
+
+    with right:
+        st.subheader("Step Detail")
+        step_options = {f"Step {s['step_id']}: {s['name']}": s for s in steps}
+        selected_step_label = st.selectbox("Inspect step", options=list(step_options.keys()), label_visibility="visible")
+        if selected_step_label:
+            s = step_options[selected_step_label]
+            st.json({
+                "step_id": s.get("step_id"),
+                "persona": s.get("persona"),
+                "execution_mode": s.get("execution_mode"),
+                "status": s.get("status"),
+                "started_at": s.get("started_at"),
+                "ended_at": s.get("ended_at"),
+                "duration_seconds": s.get("duration_seconds"),
+                "error": s.get("error"),
+            })
+
+        # Blocked errors panel
+        blocked_steps = [s for s in steps if s.get("status") == "BLOCKED"]
+        if blocked_steps:
+            st.markdown("---")
+            st.error(f"⛔ Workflow BLOCKED — {len(blocked_steps)} gate failure(s)")
+            for s in blocked_steps:
+                st.markdown(f"**Step {s['step_id']}: {s['name']}**")
+                st.code(str(s.get("error", "Unknown error")), language="text")
+
+    st.markdown("---")
+    st.caption(
+        f"Updated: {format_time(selected.get('updated_at'))}  |  "
+        "Pipeline: Step 1 → Step 2 → (Step 3 ‖ Step 4) → Step 5"
     )
-
-    col1, col2, col3, col4 = st.columns(4)
-    col1.metric("Issue", f"#{selected.get('issue_number', '-')}")
-    col2.metric("Status", str(selected.get("status", "-")))
-    col3.metric("Current Step", str(selected.get("current_step", "-")))
-    col4.metric("Updated", format_time(selected.get("updated_at")))
-
-    step_rows: list[dict[str, Any]] = []
-    for step in selected.get("steps", []):
-        step_rows.append(
-            {
-                "Step": step.get("step_id"),
-                "Name": step.get("name"),
-                "Status": step.get("status"),
-                "Start": format_time(step.get("started_at")),
-                "End": format_time(step.get("ended_at")),
-                "Duration (s)": step.get("duration_seconds"),
-            }
-        )
-
-    st.subheader("Step Timeline")
-    st.dataframe(step_rows, use_container_width=True, hide_index=True)
-
-    blocked = next(
-        (step for step in selected.get("steps", []) if step.get("status") == "BLOCKED"),
-        None,
-    )
-    if blocked:
-        st.error("Workflow is blocked and requires human intervention.")
-        st.code(str(blocked.get("error", "Unknown error")), language="text")
-
-    st.caption("Use sidebar controls to adjust auto-refresh behavior.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Implementation
- Changed: `.github/agents/issue-workflow.agent.md` — Steps 3+4 now invoked simultaneously; Step 5 gated on both completing
- Changed: `scripts/update_workflow_state.py` — added `execution_mode` per step, `--check-parallel-complete` gate command
- Changed: `workflow_dashboard.py` — full redesign with parallel lane view, status icons, metrics, step inspector

## Pipeline Shape
```
Step 1 (PO) → Step 2 (Dev) → ┌ Step 3 (Unit Tester) ┐ → Step 5 (PR Creator)
                              └ Step 4 (UI Tester)    ┘
```

## Acceptance Criteria
- [x] Steps 3 and 4 start simultaneously after Step 2 completes
- [x] Step 5 only starts when both Step 3 AND Step 4 are COMPLETED
- [x] If either Step 3 or 4 is IN_PROGRESS or BLOCKED, Step 5 does not start
- [x] --check-parallel-complete exits 2 with [WAIT] when gate not met
- [x] Dashboard renders Steps 3+4 side-by-side in a parallel lane
- [x] Dashboard shows status icons, active agent count, total duration, blocked errors