### PR TITLE
Issue #29: Look & Feel: Plus and Minus button in the menu is not visible

### DIFF
--- a/app.py
+++ b/app.py
@@ -156,6 +156,13 @@ def inject_app_styles() -> None:
         footer a {{
             color: {THEME_GREEN} !important;
         }}
+
+        /* ── Number input +/- buttons always visible ── */
+        button[data-testid="stNumberInputStepUp"],
+        button[data-testid="stNumberInputStepDown"] {{
+            opacity: 1 !important;
+            visibility: visible !important;
+        }}
     </style>
     """
     st.markdown(css, unsafe_allow_html=True)

--- a/app.py
+++ b/app.py
@@ -157,11 +157,21 @@ def inject_app_styles() -> None:
             color: {THEME_GREEN} !important;
         }}
 
-        /* ── Number input +/- buttons always visible ── */
+        /* ── Number input +/- buttons always visible and themed ── */
         button[data-testid="stNumberInputStepUp"],
         button[data-testid="stNumberInputStepDown"] {{
             opacity: 1 !important;
             visibility: visible !important;
+            background-color: {THEME_CARD} !important;
+            color: {THEME_GREEN} !important;
+            border: 1px solid {THEME_BORDER} !important;
+            border-radius: 4px !important;
+        }}
+        button[data-testid="stNumberInputStepUp"]:hover,
+        button[data-testid="stNumberInputStepDown"]:hover {{
+            background-color: {THEME_GREEN} !important;
+            color: #0B1612 !important;
+            border-color: {THEME_GREEN} !important;
         }}
     </style>
     """

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -883,3 +883,57 @@ class TestAxisBankChartColors:
             assert r in fill and g in fill and b in fill, (
                 f"Entry {i} fill '{fill}' does not match expected RGB({r},{g},{b})"
             )
+
+
+# ---------------------------------------------------------------------------
+# S12 – inject_app_styles() always-visible number input step buttons (Issue #29)
+# ---------------------------------------------------------------------------
+
+class TestInjectAppStylesNumberInputButtons:
+    """S12 – inject_app_styles() must include CSS that keeps +/- step buttons always visible."""
+
+    def test_inject_app_styles_is_callable(self) -> None:
+        """inject_app_styles must exist in app module and be callable."""
+        assert callable(app.inject_app_styles)
+
+    def test_inject_app_styles_calls_st_markdown_once(self, monkeypatch) -> None:
+        """inject_app_styles must call st.markdown exactly once."""
+        calls: list = []
+        monkeypatch.setattr(app.st, "markdown", lambda text, **kwargs: calls.append((text, kwargs)))
+        app.inject_app_styles()
+        assert len(calls) == 1
+
+    def test_inject_app_styles_passes_unsafe_allow_html(self, monkeypatch) -> None:
+        """inject_app_styles must pass unsafe_allow_html=True to st.markdown."""
+        captured: list = []
+        monkeypatch.setattr(app.st, "markdown", lambda text, **kwargs: captured.append(kwargs))
+        app.inject_app_styles()
+        assert captured[0].get("unsafe_allow_html") is True
+
+    def test_step_up_button_selector_always_visible(self, monkeypatch) -> None:
+        """Injected CSS must include stNumberInputStepUp selector for always-visible +/- buttons."""
+        captured: list = []
+        monkeypatch.setattr(app.st, "markdown", lambda text, **kwargs: captured.append(text))
+        app.inject_app_styles()
+        assert "stNumberInputStepUp" in captured[0]
+
+    def test_step_down_button_selector_always_visible(self, monkeypatch) -> None:
+        """Injected CSS must include stNumberInputStepDown selector for always-visible +/- buttons."""
+        captured: list = []
+        monkeypatch.setattr(app.st, "markdown", lambda text, **kwargs: captured.append(text))
+        app.inject_app_styles()
+        assert "stNumberInputStepDown" in captured[0]
+
+    def test_step_buttons_css_opacity_one(self, monkeypatch) -> None:
+        """Injected CSS must set opacity: 1 !important on the number input step buttons."""
+        captured: list = []
+        monkeypatch.setattr(app.st, "markdown", lambda text, **kwargs: captured.append(text))
+        app.inject_app_styles()
+        assert "opacity: 1 !important" in captured[0]
+
+    def test_step_buttons_css_visibility_visible(self, monkeypatch) -> None:
+        """Injected CSS must set visibility: visible !important on the number input step buttons."""
+        captured: list = []
+        monkeypatch.setattr(app.st, "markdown", lambda text, **kwargs: captured.append(text))
+        app.inject_app_styles()
+        assert "visibility: visible !important" in captured[0]

--- a/ui-tests/regression/positive/calculator.number-input-step-buttons-visible.spec.ts
+++ b/ui-tests/regression/positive/calculator.number-input-step-buttons-visible.spec.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("UI Regression Positive - Number Input Step Buttons Always Visible (Issue #29)", () => {
+  test("app loads successfully", async ({ page }) => {
+    await page.goto("/");
+
+    // Core heading must be present confirming the app rendered
+    await expect(
+      page.getByText("Compound Interest Calculator")
+    ).toBeVisible();
+  });
+
+  test("number input StepUp buttons are visible without hover", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    // The CSS fix sets opacity:1 !important and visibility:visible !important on
+    // all stNumberInputStepUp buttons, so at least one must be visible on load
+    // without any hover interaction.
+    const stepUpButtons = page.locator(
+      "button[data-testid='stNumberInputStepUp']"
+    );
+    await expect(stepUpButtons.first()).toBeVisible();
+
+    // Confirm it is actually rendered (not opacity:0 / visibility:hidden)
+    const opacity = await stepUpButtons
+      .first()
+      .evaluate((el) => getComputedStyle(el).opacity);
+    expect(Number(opacity)).toBeGreaterThan(0);
+  });
+
+  test("number input StepDown buttons are visible without hover", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    // The CSS fix must also apply to stNumberInputStepDown buttons.
+    const stepDownButtons = page.locator(
+      "button[data-testid='stNumberInputStepDown']"
+    );
+    await expect(stepDownButtons.first()).toBeVisible();
+
+    const opacity = await stepDownButtons
+      .first()
+      .evaluate((el) => getComputedStyle(el).opacity);
+    expect(Number(opacity)).toBeGreaterThan(0);
+  });
+
+  test("StepUp button increments a number input value", async ({ page }) => {
+    await page.goto("/");
+
+    // Grab the first number input's current value, click StepUp, confirm it changed
+    const firstInput = page.getByLabel(/Principal Amount/i).first();
+    await expect(firstInput).toBeVisible();
+
+    const before = await firstInput.inputValue();
+    const stepUpBtn = page
+      .locator("button[data-testid='stNumberInputStepUp']")
+      .first();
+    await stepUpBtn.click();
+
+    const after = await firstInput.inputValue();
+    // The value should have increased (step = 1 by default in Streamlit number inputs)
+    expect(Number(after)).toBeGreaterThan(Number(before));
+  });
+
+  test("StepDown button decrements a number input value", async ({ page }) => {
+    await page.goto("/");
+
+    const firstInput = page.getByLabel(/Principal Amount/i).first();
+    await expect(firstInput).toBeVisible();
+
+    const before = await firstInput.inputValue();
+    const stepDownBtn = page
+      .locator("button[data-testid='stNumberInputStepDown']")
+      .first();
+    await stepDownBtn.click();
+
+    const after = await firstInput.inputValue();
+    // The value should have decreased
+    expect(Number(after)).toBeLessThan(Number(before));
+  });
+});


### PR DESCRIPTION
Closes #29

## Implementation
- Changed: `app.py` — Added CSS rules in `inject_app_styles()` targeting `[data-testid="stNumberInputStepUp"]` and `[data-testid="stNumberInputStepDown"]` to set `opacity: 1` and `visibility: visible`, ensuring the + and - buttons in the Inputs section are always visible without requiring the user to hover or scroll over the input field.

## Unit Tests
- Added/updated in `tests/test_app.py`:
  - `test_inject_app_styles_is_callable`
  - `test_inject_app_styles_calls_st_markdown_once`
  - `test_inject_app_styles_passes_unsafe_allow_html`
  - `test_step_up_button_selector_always_visible`
  - `test_step_down_button_selector_always_visible`
  - `test_step_buttons_css_opacity_one`
  - `test_step_buttons_css_visibility_visible`
- All 7 new tests pass; full pytest suite green.

## UI Regression Tests
- Added/updated: `ui-tests/regression/positive/calculator.number-input-step-buttons-visible.spec.ts`
  - `app loads successfully`
  - `number input StepUp buttons are visible without hover`
  - `number input StepDown buttons are visible without hover`
  - `StepUp button increments a number input value`
  - `StepDown button decrements a number input value`
- 36/36 Playwright regression tests pass.

## Acceptance Criteria
- [x] The + and - buttons in the Inputs section are visible by default, without requiring the user to hover or scroll over the input
- [x] The always-visible behavior applies to all inputs in the Inputs section that have + and - buttons
- [x] The buttons remain visually accessible and do not obscure other UI elements