### PR TITLE
Issue #37: Add Bi-Weekly compounding frequency (26 periods/year)

### DIFF
--- a/app.py
+++ b/app.py
@@ -185,6 +185,7 @@ FREQUENCY_OPTIONS = {
     "Quarterly": 4,
     "Monthly": 12,
     "Semi-Monthly": 24,
+    "Bi-Weekly": 26,
     "Weekly": 52,
     "Daily": 365,
 }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -135,6 +135,54 @@ class TestFrequencyImpact:
         assert "Semi-Monthly" in app.FREQUENCY_OPTIONS
         assert app.FREQUENCY_OPTIONS["Semi-Monthly"] == 24
 
+    # ------------------------------------------------------------------
+    # Issue #37 – Bi-Weekly (26 periods/year)
+    # ------------------------------------------------------------------
+
+    def test_bi_weekly_mapping_exists(self) -> None:
+        # Issue #37: "Bi-Weekly" must be present in FREQUENCY_OPTIONS
+        assert "Bi-Weekly" in app.FREQUENCY_OPTIONS
+
+    def test_bi_weekly_mapped_to_26_periods(self) -> None:
+        # Issue #37: Bi-Weekly must map to exactly 26 compounding periods per year
+        assert app.FREQUENCY_OPTIONS["Bi-Weekly"] == 26
+
+    def test_bi_weekly_frequency_compounds_correctly(self) -> None:
+        # Issue #37: Bi-Weekly (n=26) must produce a higher balance than
+        # Semi-Monthly (n=24) and a lower balance than Weekly (n=52).
+        semi_monthly = _balance(10000.0, 0.0, 6.0, 10.0, 24)
+        bi_weekly    = _balance(10000.0, 0.0, 6.0, 10.0, 26)
+        weekly       = _balance(10000.0, 0.0, 6.0, 10.0, 52)
+        assert bi_weekly > semi_monthly, (
+            "Bi-Weekly (n=26) should compound more than Semi-Monthly (n=24)"
+        )
+        assert bi_weekly < weekly, (
+            "Bi-Weekly (n=26) should compound less than Weekly (n=52)"
+        )
+
+    def test_bi_weekly_balance_formula(self) -> None:
+        # Issue #37: Verify the exact compound formula for n=26 over 1 year at 12%
+        # FV = P * (1 + 0.12/26)^26
+        principal = 1000.0
+        rate = 12.0
+        years = 1.0
+        n = 26
+        expected = principal * (1 + (rate / 100) / n) ** (n * years)
+        result = _balance(principal, 0.0, rate, years, n)
+        assert isclose(result, expected, rel_tol=1e-12)
+
+    def test_bi_weekly_ordered_between_semi_monthly_and_weekly_in_options(self) -> None:
+        # Issue #37: FREQUENCY_OPTIONS must contain "Bi-Weekly" between
+        # "Semi-Monthly" and "Weekly" in iteration order.
+        keys = list(app.FREQUENCY_OPTIONS.keys())
+        assert "Bi-Weekly" in keys
+        assert keys.index("Bi-Weekly") > keys.index("Semi-Monthly"), (
+            '"Bi-Weekly" must appear after "Semi-Monthly" in FREQUENCY_OPTIONS'
+        )
+        assert keys.index("Bi-Weekly") < keys.index("Weekly"), (
+            '"Bi-Weekly" must appear before "Weekly" in FREQUENCY_OPTIONS'
+        )
+
     def test_semi_monthly_frequency_compounds_correctly(self) -> None:
         # Issue #16: Semi-Monthly (n=24) should produce a higher balance than
         # Monthly (n=12) and a lower balance than Weekly (n=52) at a positive rate.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1202,8 +1202,8 @@ class TestDefaults:
         assert keys[3] == "Monthly"
 
     def test_frequency_options_contains_all_seven(self) -> None:
-        """FREQUENCY_OPTIONS must contain all 7 frequencies."""
-        expected = {"Annually", "Half Yearly", "Quarterly", "Monthly", "Semi-Monthly", "Weekly", "Daily"}
+        """FREQUENCY_OPTIONS must contain all 8 frequencies (updated for Bi-Weekly — Issue #37)."""
+        expected = {"Annually", "Half Yearly", "Quarterly", "Monthly", "Semi-Monthly", "Bi-Weekly", "Weekly", "Daily"}
         assert set(app.FREQUENCY_OPTIONS.keys()) == expected
 
     def test_currency_symbol_inr(self) -> None:

--- a/ui-tests/regression/bi-weekly.spec.ts
+++ b/ui-tests/regression/bi-weekly.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+
+test('Bi-Weekly dropdown option is visible, selectable, and computes correctly', async ({ page }) => {
+  // Navigate to the running Streamlit app using the configured baseURL
+  await page.goto('/');
+
+  // Open the Compounding Frequency selectbox and verify "Bi-Weekly" appears
+  await page.getByLabel('Compounding Frequency').click();
+  await expect(page.getByText('Bi-Weekly', { exact: true })).toBeVisible();
+
+  // Select Bi-Weekly and verify the summary caption reflects it
+  await page.getByText('Bi-Weekly', { exact: true }).click();
+  await expect(page.getByText(/Projected using bi-weekly compounding/i)).toBeVisible();
+});

--- a/ui-tests/regression/weekly.spec.ts
+++ b/ui-tests/regression/weekly.spec.ts
@@ -9,11 +9,13 @@ test('Weekly dropdown option and summary update', async ({ page }) => {
   const compSelect = page.getByLabel('Compounding Frequency');
   await expect(compSelect).toBeVisible();
 
-  // Open the select and ensure Weekly appears as an option
+  // Open the select and ensure Weekly appears as an option.
+  // Use exact: true to avoid matching "Bi-Weekly" which also contains "Weekly".
   await compSelect.click();
-  await expect(page.getByText('Weekly')).toBeVisible();
+  await expect(page.getByText('Weekly', { exact: true })).toBeVisible();
 
-  // Select Weekly and verify the summary caption updates accordingly
-  await page.getByText('Weekly').click();
+  // Select Weekly and verify the summary caption updates accordingly.
+  // Use exact: true to click the correct "Weekly" option (not "Bi-Weekly").
+  await page.getByText('Weekly', { exact: true }).click();
   await expect(page.getByText(/Projected using weekly compounding/i)).toBeVisible();
 });


### PR DESCRIPTION
Closes #37

## Implementation
- **app.py** — Added `"Bi-Weekly": 26` to the `FREQUENCY_OPTIONS` dictionary, giving bi-weekly compounding 26 periods per year, consistent with all existing frequency entries.
- **ui-tests/regression/weekly.spec.ts** — Changed `getByText('Weekly')` to `getByText('Weekly', { exact: true })` to prevent selector ambiguity now that a "Bi-Weekly" option also exists in the dropdown.

## Unit Tests
- Added: `test_bi_weekly_mapping_exists`
- Added: `test_bi_weekly_mapped_to_26_periods`
- Added: `test_bi_weekly_frequency_compounds_correctly`
- Added: `test_bi_weekly_balance_formula`
- Added: `test_bi_weekly_ordered_between_semi_monthly_and_weekly_in_options`
- Updated: `test_frequency_options_contains_all_seven` → now expects 8 options (including Bi-Weekly)
- All 190 unit tests pass.

## UI Regression Tests
- Added: `ui-tests/regression/bi-weekly.spec.ts` — scenario: "Bi-Weekly dropdown option is visible, selectable, and computes correctly"
- All 60 Playwright tests pass.

## Acceptance Criteria
- [x] A "Bi-Weekly" option appears in the compounding frequency dropdown/selection list
- [x] Selecting "Bi-Weekly" computes compound interest using **26 compounding periods per year**
- [x] All screens that display or use the compounding frequency are updated to include the "Bi-Weekly" option
- [x] The calculated result when "Bi-Weekly" is selected is correct and consistent with the existing compounding frequency logic